### PR TITLE
fix double onload problem

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,8 +182,11 @@ li
 
 
 <body>
+  
     <script>
-        if (!window.crypto || !window.crypto.getRandomValues)
+        console.log('window.crypto', window.crypto);
+// The line of code below checks if your browser can generate random values
+        if (!window.crypto || !window.crypto.getRandomValues )
         {
             window.onload = function()
             {
@@ -7029,161 +7032,168 @@ li
         var randomnessCanvasResizerFunction;
         var randomnessBytes = undefined;
         
-        window.onload = function()
+        if (!window.crypto || !window.crypto.getRandomValues )
         {
-            var newLink = document.createElement("link");
-            newLink.rel = "shortcut icon";
-            newLink.type = "image/png";
-            newLink.href = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAKTWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQWaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28AAgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaOWJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHiwmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryMAgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0lYqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHiNLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYAQH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6cwR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBiewhi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1cQPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqOY4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hMWEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgohJZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSUEko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/pdLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Yb1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7OUndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsbdi97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxrPGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H08PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+Hvqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsGLww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjgR2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWYEpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1IreZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/PbFWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYji1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVkVe9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0IbwDa0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vzDoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+yCW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawto22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtdUV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3rO9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv9563Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMAAPn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAACbUlEQVR42myTS0iUURTHf+fO9803M04+hlQw0VAqg1IyMqGsRRlS0KYnURRUm4ggCFoG0aZNKxehGxeSm8CdkAQG0UITS4qoQKKHUjPlNOl88/get8XM5KSezeVefv9z//ece6ShJcOqaI/UyW03yyE3rWs1YEaIi5LxXEo/AGbLYSlLEIrUy1Amoc9ov3AQjgleRpMvIYK2KmUkl9JXARvAKInDG+Wl/UPvKIKgoeOWgb/sYc8JmQVh7rkruZQ+F9zA9vwS+4CMAohukuHMz4I4VKO4MGnR2x+ktUeRjSu2XTRxKlZs55fYFYwyWHpCuyhmS7aVAQ3dwtEhq+CkGJ/HfKbuuyS/+ZS53K0qm+ROSQzgu7A0JyCQeOsy3JVj6r5HU5/i+GgQq7qYVYNZwQ2VX+bg6jbUdxbWhRcK+5fm9YBD+quPFYOaZilHjxj5lK5ZnaB2bwFqO6mItVgYUSHaDH8+ahLvV+y6GeqUZm007g+AholrDokZn+qtGjS8GfTwcv+zyqqSZGkTbVQ0dAWoalYsv4Mv0x7TAw7j110Q6L5rIIEVsREmbpgVPMsucgLgwD2Txh4p/Rla+wzSCx6bjxVU+TSUF1xrxqWhJdOB8AqNBCyo6whw+KGJ8x02bAFR/Kv65D2P2SGnvI17DGA2UiuP7bg+5eUg+cHHqoDRy3nOTgQZO+9ihuDPJ5/FL365/UeuzbQBYMf1pVC1tGV/651eXvP0ikswqpkf18xPumuKbEaYcWyurh6mcCgmQ9mkPs16rSnaNsOMODZXSsMk64xzp1UlN7Wve500G4s3JnyfJ65NPzBdDv8dAPwl9qfQLkNMAAAAAElFTkSuQmCC";
-            document.getElementsByTagName("head")[0].appendChild(newLink);
-            
-            document.getElementById("view_address_privkey_textbox").addEventListener("keydown", function(event)
+            window.onload = function()
             {
-                if (event.keyCode === 13)
-                {
-                    event.preventDefault();
-                    view_address_details();
-                }
-            });
-            
-            document.getElementById("view_address_bip38_password_textbox").addEventListener("keydown", function(event)
+                document.write("Your browser is unable to generate cryptographically strong random values. Please use a newer one.<br />Recommended browsers:<br /><a href=\"https://www.google.com/chrome/\">Google Chrome</a><br /><a href=\"https://www.mozilla.org/firefox/\">Mozilla Firefox</a><br /><a href=\"https://www.opera.com/\">Opera browser</a>");
+            };
+        } else
+            window.onload = function()
             {
-                if (event.keyCode === 13)
-                {
-                    event.preventDefault();
-                    bip38decrypt_button();
-                }
-            });
-            
-            document.getElementById("bulk_count").addEventListener("keydown", function(event)
-            {
-                if (event.keyCode === 13)
-                {
-                    event.preventDefault();
-                    bulk_generate();
-                }
-            });
-            
-            bulkTextarea = document.getElementById("bulk_addresses");
-            paperWalletTextArea = document.getElementById("paperwallet_generate_progress_text");
-            
-            
-            document.getElementById("randomness_overlay2").style.display = "table";
-            var randomnessCanvas = document.getElementById("randomness_canvas");
-            var ctx = randomnessCanvas.getContext("2d");
-            var randomnessText = document.getElementById("randomness_div");
-            
-            randomnessCanvasResizerFunction = function()
-            {
-                var width = document.documentElement.clientWidth;
-                var height = document.documentElement.clientHeight;
-                var canvasWidth = width * 0.7;
-                var canvasHeight = height * 0.6;
+                var newLink = document.createElement("link");
+                newLink.rel = "shortcut icon";
+                newLink.type = "image/png";
+                newLink.href = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAKTWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQWaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28AAgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaOWJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHiwmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryMAgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0lYqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHiNLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYAQH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6cwR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBiewhi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1cQPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqOY4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hMWEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgohJZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSUEko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/pdLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Yb1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7OUndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsbdi97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxrPGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H08PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+Hvqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsGLww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjgR2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWYEpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1IreZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/PbFWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYji1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVkVe9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0IbwDa0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vzDoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+yCW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawto22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtdUV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3rO9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv9563Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMAAPn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAACbUlEQVR42myTS0iUURTHf+fO9803M04+hlQw0VAqg1IyMqGsRRlS0KYnURRUm4ggCFoG0aZNKxehGxeSm8CdkAQG0UITS4qoQKKHUjPlNOl88/get8XM5KSezeVefv9z//ece6ShJcOqaI/UyW03yyE3rWs1YEaIi5LxXEo/AGbLYSlLEIrUy1Amoc9ov3AQjgleRpMvIYK2KmUkl9JXARvAKInDG+Wl/UPvKIKgoeOWgb/sYc8JmQVh7rkruZQ+F9zA9vwS+4CMAohukuHMz4I4VKO4MGnR2x+ktUeRjSu2XTRxKlZs55fYFYwyWHpCuyhmS7aVAQ3dwtEhq+CkGJ/HfKbuuyS/+ZS53K0qm+ROSQzgu7A0JyCQeOsy3JVj6r5HU5/i+GgQq7qYVYNZwQ2VX+bg6jbUdxbWhRcK+5fm9YBD+quPFYOaZilHjxj5lK5ZnaB2bwFqO6mItVgYUSHaDH8+ahLvV+y6GeqUZm007g+AholrDokZn+qtGjS8GfTwcv+zyqqSZGkTbVQ0dAWoalYsv4Mv0x7TAw7j110Q6L5rIIEVsREmbpgVPMsucgLgwD2Txh4p/Rla+wzSCx6bjxVU+TSUF1xrxqWhJdOB8AqNBCyo6whw+KGJ8x02bAFR/Kv65D2P2SGnvI17DGA2UiuP7bg+5eUg+cHHqoDRy3nOTgQZO+9ihuDPJ5/FL365/UeuzbQBYMf1pVC1tGV/651eXvP0ikswqpkf18xPumuKbEaYcWyurh6mcCgmQ9mkPs16rSnaNsOMODZXSsMk64xzp1UlN7Wve500G4s3JnyfJ65NPzBdDv8dAPwl9qfQLkNMAAAAAElFTkSuQmCC";
+                document.getElementsByTagName("head")[0].appendChild(newLink);
                 
-                var imageData = undefined;
-                if (randomnessCanvas.width > 0 && randomnessCanvas.height > 0)
-                    imageData = ctx.getImageData(0, 0, randomnessCanvas.width, randomnessCanvas.height);
+                document.getElementById("view_address_privkey_textbox").addEventListener("keydown", function(event)
+                {
+                    if (event.keyCode === 13)
+                    {
+                        event.preventDefault();
+                        view_address_details();
+                    }
+                });
                 
-                var prevFillStyle = ctx.fillStyle;
+                document.getElementById("view_address_bip38_password_textbox").addEventListener("keydown", function(event)
+                {
+                    if (event.keyCode === 13)
+                    {
+                        event.preventDefault();
+                        bip38decrypt_button();
+                    }
+                });
                 
-                randomnessCanvas.width = canvasWidth;
-                randomnessCanvas.height = canvasHeight;
-                randomnessCanvas.style.left = (width / 2 - canvasWidth / 2) + "px";
-                randomnessCanvas.style.top = (height / 2 - canvasHeight / 1.5) + "px";
+                document.getElementById("bulk_count").addEventListener("keydown", function(event)
+                {
+                    if (event.keyCode === 13)
+                    {
+                        event.preventDefault();
+                        bulk_generate();
+                    }
+                });
+                
+                bulkTextarea = document.getElementById("bulk_addresses");
+                paperWalletTextArea = document.getElementById("paperwallet_generate_progress_text");
+                
+                
+                document.getElementById("randomness_overlay2").style.display = "table";
+                var randomnessCanvas = document.getElementById("randomness_canvas");
+                var ctx = randomnessCanvas.getContext("2d");
+                var randomnessText = document.getElementById("randomness_div");
+                
+                randomnessCanvasResizerFunction = function()
+                {
+                    var width = document.documentElement.clientWidth;
+                    var height = document.documentElement.clientHeight;
+                    var canvasWidth = width * 0.7;
+                    var canvasHeight = height * 0.6;
+                    
+                    var imageData = undefined;
+                    if (randomnessCanvas.width > 0 && randomnessCanvas.height > 0)
+                        imageData = ctx.getImageData(0, 0, randomnessCanvas.width, randomnessCanvas.height);
+                    
+                    var prevFillStyle = ctx.fillStyle;
+                    
+                    randomnessCanvas.width = canvasWidth;
+                    randomnessCanvas.height = canvasHeight;
+                    randomnessCanvas.style.left = (width / 2 - canvasWidth / 2) + "px";
+                    randomnessCanvas.style.top = (height / 2 - canvasHeight / 1.5) + "px";
+                    
+                    ctx.fillStyle = "#ffffff";
+                    ctx.fillRect(0, 0, randomnessCanvas.width, randomnessCanvas.height);
+                    ctx.fillStyle = prevFillStyle;
+                    
+                    if (imageData !== undefined)
+                        ctx.putImageData(imageData, 0, 0);
+                    
+                    randomnessText.style.left = (width / 2 - randomnessText.clientWidth / 2) + "px";
+                    randomnessText.style.top = (height / 2 - canvasHeight / 1.5) + "px";
+                    
+                    var randomnessContainer = document.getElementById("randomness_container");
+                    randomnessContainer.style.width = canvasWidth + "px";
+                    randomnessContainer.style.left = (width / 2 - canvasWidth / 2) + "px";
+                    randomnessContainer.style.top = (height / 2 + canvasHeight / 3 + 10) + "px";
+                }
+                
+                window.addEventListener("resize", randomnessCanvasResizerFunction);
+                randomnessCanvasResizerFunction();
                 
                 ctx.fillStyle = "#ffffff";
                 ctx.fillRect(0, 0, randomnessCanvas.width, randomnessCanvas.height);
-                ctx.fillStyle = prevFillStyle;
-                
-                if (imageData !== undefined)
-                    ctx.putImageData(imageData, 0, 0);
-                
-                randomnessText.style.left = (width / 2 - randomnessText.clientWidth / 2) + "px";
-                randomnessText.style.top = (height / 2 - canvasHeight / 1.5) + "px";
-                
-                var randomnessContainer = document.getElementById("randomness_container");
-                randomnessContainer.style.width = canvasWidth + "px";
-                randomnessContainer.style.left = (width / 2 - canvasWidth / 2) + "px";
-                randomnessContainer.style.top = (height / 2 + canvasHeight / 3 + 10) + "px";
-            }
-            
-            window.addEventListener("resize", randomnessCanvasResizerFunction);
-            randomnessCanvasResizerFunction();
-            
-            ctx.fillStyle = "#ffffff";
-            ctx.fillRect(0, 0, randomnessCanvas.width, randomnessCanvas.height);
-            var tempRandomnessBytes = [];
-            var randomnessIndex = 0;
-            var randomnessMax = 1000;
-            randomnessCanvas.onmousemove = function(e)
-            {
-                if (randomnessIndex > randomnessMax)
+                var tempRandomnessBytes = [];
+                var randomnessIndex = 0;
+                var randomnessMax = 1000;
+                randomnessCanvas.onmousemove = function(e)
                 {
-                    window.removeEventListener("resize", randomnessCanvasResizerFunction);
+                    if (randomnessIndex > randomnessMax)
+                    {
+                        window.removeEventListener("resize", randomnessCanvasResizerFunction);
+                        
+                        randomnessBytes = [];
+                        randomnessBytes.push.apply(randomnessBytes, crypto.getRandomValues(new Uint32Array(32)));
+                        randomnessBytes.push.apply(randomnessBytes, tempRandomnessBytes);
+                        randomnessCanvas.onmousemove = null;
+                        randomnessIndex = 0;
+                        tempRandomnessBytes = undefined;
+                        generate_address();
+                        document.getElementById("randomness_overlay").style.display = "none";
+                        return;
+                    }
                     
-                    randomnessBytes = [];
-                    randomnessBytes.push.apply(randomnessBytes, crypto.getRandomValues(new Uint32Array(32)));
-                    randomnessBytes.push.apply(randomnessBytes, tempRandomnessBytes);
-                    randomnessCanvas.onmousemove = null;
-                    randomnessIndex = 0;
-                    tempRandomnessBytes = undefined;
-                    generate_address();
-                    document.getElementById("randomness_overlay").style.display = "none";
-                    return;
+                    var rect = e.target.getBoundingClientRect();
+                    var x = e.clientX - rect.left;
+                    var y = e.clientY - rect.top;
+                    //randomnessCanvas.fillRect(x - 3, y - 3, 6, 6);
+                    ctx.beginPath();
+                    ctx.arc(x, y, 4, 0, 6.3);
+                    ctx.fill();
+                    randomnessText.innerHTML = "Move your mouse around here for randomness<br />" + Math.floor(randomnessIndex / randomnessMax * 100) + "%";
+                    
+                    tempRandomnessBytes[randomnessIndex++] = e.clientX + e.clientY * document.documentElement.clientWidth;
+                };
+                
+                ctx.fillStyle = "#5b96f7";
+                
+                
+                if (window.location.protocol != "file:")
+                {
+                    var warningText = document.createElement("div");
+                    warningText.innerHTML = "Warning: it seems you're running this generator from a live website. For valuable wallets, it is highly recommended to run the site from an offline computer. You can save this website by pressing CTRL-S or right click -> Save website (or something)<br /><br /><a href=\"javascript:void(0)\" onclick=\"document.getElementById('warning_text').innerHTML=''\">Hide warning</a>";
+                    warningText.style = "font-size: 21px; color: #ff0000; margin-top: 30px;";
+                    warningText.id = "warning_text";
+                    document.getElementById("button_container").appendChild(warningText);
                 }
                 
-                var rect = e.target.getBoundingClientRect();
-                var x = e.clientX - rect.left;
-                var y = e.clientY - rect.top;
-                //randomnessCanvas.fillRect(x - 3, y - 3, 6, 6);
-                ctx.beginPath();
-                ctx.arc(x, y, 4, 0, 6.3);
-                ctx.fill();
-                randomnessText.innerHTML = "Move your mouse around here for randomness<br />" + Math.floor(randomnessIndex / randomnessMax * 100) + "%";
+                layoutPrintAreas = 
+                {
+                    "generate":
+                    {
+                        "address_div": "print_visible",
+                    },
+                    "details":
+                    {
+                        "view_address_div": "print_visible",
+                    },
+                    "bulk":
+                    {
+                        "bulk_addresses": "print_visible",
+                    },
+                    "paper":
+                    {
+                        "paperwallet_canvas_print_container": "print_container",
+                        "paperwallet_print_area": "print_visible",
+                    },
+                    "info":
+                    {
+                        "main_info": "print_visible",
+                    },
+                };
                 
-                tempRandomnessBytes[randomnessIndex++] = e.clientX + e.clientY * document.documentElement.clientWidth;
+                currentLayout = "generate";
             };
-            
-            ctx.fillStyle = "#5b96f7";
-            
-            
-            if (window.location.protocol != "file:")
-            {
-                var warningText = document.createElement("div");
-                warningText.innerHTML = "Warning: it seems you're running this generator from a live website. For valuable wallets, it is highly recommended to run the site from an offline computer. You can save this website by pressing CTRL-S or right click -> Save website (or something)<br /><br /><a href=\"javascript:void(0)\" onclick=\"document.getElementById('warning_text').innerHTML=''\">Hide warning</a>";
-                warningText.style = "font-size: 21px; color: #ff0000; margin-top: 30px;";
-                warningText.id = "warning_text";
-                document.getElementById("button_container").appendChild(warningText);
-            }
-            
-            layoutPrintAreas = 
-            {
-                "generate":
-                {
-                    "address_div": "print_visible",
-                },
-                "details":
-                {
-                    "view_address_div": "print_visible",
-                },
-                "bulk":
-                {
-                    "bulk_addresses": "print_visible",
-                },
-                "paper":
-                {
-                    "paperwallet_canvas_print_container": "print_container",
-                    "paperwallet_print_area": "print_visible",
-                },
-                "info":
-                {
-                    "main_info": "print_visible",
-                },
-            };
-            
-            currentLayout = "generate";
-        };
-    
+        
         // secp256k1 parameters
         var ecc_p =  new BN("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F", 16);
         var ecc_a =  new BN(0);

--- a/test.html
+++ b/test.html
@@ -1,0 +1,37 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>The HTML5 Herald</title>
+  <meta name="description" content="The HTML5 Herald">
+  <meta name="author" content="SitePoint">
+
+  <!link rel="stylesheet" href="css/styles.css?v=1.0">
+
+</head>
+<body>
+  <!script src="js/scripts.js"></script>
+      <script>
+        console.log('window.crypto', window.crypto);
+// The line of code below checks if your browser can generate random values
+        // if (true || !window.crypto || !window.crypto.getRandomValues )
+        if (true)
+        {
+          
+          console.log('fuck you');
+            window.onload = function()
+            {
+                document.write("Your browser is unable to generate cryptographically strong random values. Please use a newer one.<br />Recommended browsers:<br /><a href=\"https://www.google.com/chrome/\">Google Chrome</a><br /><a href=\"https://www.mozilla.org/firefox/\">Mozilla Firefox</a><br /><a href=\"https://www.opera.com/\">Opera browser</a>");
+            };
+        }
+        
+          window.onload = function()
+            {
+                document.write("I overwrite you?")
+            };
+    </script>
+  <p>Here I Am</p>
+</body>
+</html>


### PR DESCRIPTION
Hi Kimbatt,

First let me say thank you for creating your Bitcoin Address Generator.  It was a project that was needed and your layout looks great.

I cloned your https://kimbatt.github.io/btc-address-generator/ and was looking at the code.  Starting on line 186 of index.html you check if the browser can generate random values (if (!window.crypto || !window.crypto.getRandomValues ).  If not, you tell people to download a modern browser.  

I started playing with this code to see how it works and I could not get the warning to post to the screen.  I tried that section of code in a test file and it worked perfectly.  The problem appears to be that you have two window.onload event handlers.  The second window.onload event handler is somewhere near line 7035.  According to this stackoverflow thread and my testing (https://stackoverflow.com/questions/9568006/prevent-window-onload-being-overridden-javascript
) the second window.onload will overwrite the first window.onload.  

My solution was to put the first window.onload just above the second.  Use an if-else statement that fires the first window.onload if the user’s browser does not support window.crypto.getRandomValues and to fire the second window.onload if the user’s browser does support window.crypto.getRandomValues.  This may not be the way you want to handle this issue.


BTW: I am part of a two person team that has created a multi crypto paper wallet checker.  See http://www.1337ipjbp7u9mi9cdlngl3g5napum7twzm.com/.  We just changed it to React from Jquery and are still adding features. 